### PR TITLE
Update datagrid.stub

### DIFF
--- a/src/stubs/datagrid.stub
+++ b/src/stubs/datagrid.stub
@@ -24,7 +24,7 @@ class $CLASS$ extends DataGrid
      *
      * @return void
      */
-    public function addColumns()
+    public function prepareColumns()
     {
         $this->addColumn([
             'index'      => 'id',


### PR DESCRIPTION
abstract class DataGrid requires the implement prepareColumn method in the new 2.0 Bagisto version. In the previous version method was named addColumns