### PR TITLE
Update shipping-method-system.stub

### DIFF
--- a/src/stubs/scaffold/shipping-method-system.stub
+++ b/src/stubs/scaffold/shipping-method-system.stub
@@ -5,6 +5,7 @@ return [
         'key'    => 'sales.carriers.$LOWER_NAME$',
         'name'   => '$CAPITALIZE_NAME$',
         'sort'   => 1,
+        'info'   => 'Information about $CAPITALIZE_NAME$',
         'fields' => [
             [
                 'name'          => 'title',


### PR DESCRIPTION
Fix missing info field in shipping carrier configuration

Resolves error in SystemConfig.php line 107 by adding required 'info' field to carrier configuration array.